### PR TITLE
Simplify PHPCS usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ matrix:
 install: composer install --no-interaction --optimize-autoloader --prefer-dist
 script:
   - ./vendor/bin/phpunit
-  - ./vendor/bin/phpcs --standard=PSR2 src/
+  - ./vendor/bin/phpcs

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="Recipe Scraper Coding Standards">
+    <arg name="colors" />
+    <arg name="extensions" value="php" />
+    <arg value="ps" />
+
+    <description>PSR-2 Plus some extras...</description>
+
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <file>.</file>
+
+    <rule ref="PSR2" />
+</ruleset>


### PR DESCRIPTION
Defines coding standards via phpcs.xml.dist to allow phpcs to be called without any arguments [skip ci]