### PR TITLE
Add New Dom Crawler Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": ">=7.0",
     "symfony/css-selector": "^3.0|^4.0|^5.0",
-    "symfony/dom-crawler": "^3.1|^4.0"
+    "symfony/dom-crawler": "^3.1|^4.0|^5.0"
   },
   "require-dev": {
     "psy/psysh": "^0.8",


### PR DESCRIPTION
Thanks for the package. Using it with a Laravel 8 Application and most packages are now requiring Dom Crawler 5.

Tested with BBC Good Food, the default one in your example and it brings back the same result. Any issues let me know.

Thanks again.